### PR TITLE
Fix the issues to detect correct systems for 558 test PDF files

### DIFF
--- a/src/incipit/cli.py
+++ b/src/incipit/cli.py
@@ -20,7 +20,7 @@ import incipit.heuristics
 @click.option("-c", "--count", is_flag=True, help="Output number of detected systems")
 @click.option("-p", "--pages", type=str, help="List of pages to process (e.g., '0', '0,-1')")
 @click.option("-#", "--systems", type=str, help="List of systems to extract (e.g., '0', '0,-1')")
-@click.option("-h", "--height-threshold", type=float, default=10.0, help="% of height threshold for system detection")
+@click.option("-h", "--height-threshold", type=float, default=9.0, help="% of height threshold for system detection")
 @click.option("-w", "--width-threshold", type=float, default=70.0, help="% of width threshold for system detection")
 @click.option("-o", "--output", help="Output file pattern")
 @click.option("-v", "--verbose", is_flag=True, default=False, help="Print debug information")

--- a/src/incipit/heuristics.py
+++ b/src/incipit/heuristics.py
@@ -10,7 +10,7 @@ import incipit.processing
 def detect_staves_from_input_document(
         input_path: str,
         width_proportion: float = 70.0,
-        height_proportion: float = 10.0,
+        height_proportion: float = 9.0,
         page_numbers_to_keep: typing.Optional[typing.List[int]] = None,
 ) -> typing.List[incipit.processing.IndexedRegion]:
 
@@ -46,7 +46,7 @@ def write_staff_detection_images_from_input_document(
         input_path: str,
         output_filename_pattern: str,
         width_proportion: float = 70.0,
-        height_proportion: float = 10.0,
+        height_proportion: float = 9.0,
         page_numbers_to_keep: typing.Optional[typing.List[int]] = None,
 ) -> typing.List[str]:
 
@@ -78,7 +78,7 @@ def extract_staves_from_input_document(
         output_filename_pattern: typing.Optional[str] = None,
         staves_to_keep: typing.Optional[typing.List[int]] = None,
         width_proportion: float = 70.0,
-        height_proportion: float = 10.0,
+        height_proportion: float = 9.0,
         page_numbers_to_keep: typing.Optional[typing.List[int]] = None,
 ) -> typing.Union[
         typing.List[incipit.processing.Image],

--- a/src/incipit/processing.py
+++ b/src/incipit/processing.py
@@ -319,9 +319,9 @@ def detect_regions_from_image(
     thresh = cv2.adaptiveThreshold(
         src=blur,
         maxValue=255,
-        adaptiveMethod=cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+        adaptiveMethod=cv2.ADAPTIVE_THRESH_MEAN_C,
         thresholdType=cv2.THRESH_BINARY_INV,
-        blockSize=11,
+        blockSize=9,
         C=30)
     log_intermediate_image(img=thresh, caption="3_adaptive_threshold")
 
@@ -332,8 +332,8 @@ def detect_regions_from_image(
     dilate = cv2.dilate(
         src=thresh,
         kernel=kernel,
-        iterations=4)
-    log_intermediate_image(img=thresh, caption="4_dilated")
+        iterations=2)
+    log_intermediate_image(img=thresh, caption="2_dilated")
 
     # Find contours, highlight text areas, and extract ROIs
     contours = cv2.findContours(dilate, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)


### PR DESCRIPTION
There are a few changes made:
1) One major issue was the code often detects 2 half systems instead of a full one.  To address this issue, I am now using ADAPTIVE_THRESH_MEAN_C instead of ADAPTIVE_THRESH_GAUSSIAN_C at adaptiveThreshold method to calculate a better threshold, so that the thin lines can be widened to better connect the top and bottom half of the systems; 
2) To address the same issue above, I also reduce the blockSize to 9 at adaptiveThreshold method for more accurate local threshold
3) If the neighboring systems are very close, the code often detects them as a big one instead of two separate ones. I reduced the iterations from 4 to 2 for dilate method so the neighboring systems can be clearly divided. The less iterations here, the better neighboring systems can be divided
4) There are some valid systems not qualified due to their small height. I changed the height-threshold for valid system from 10% to 9% to better detect such edge cases.
